### PR TITLE
Use existing system user instead create tim

### DIFF
--- a/make-tim.sh
+++ b/make-tim.sh
@@ -7,7 +7,18 @@ stat $WHO > /dev/null || (echo You must mount a file to "$WHO" in order to prope
 USERID=$(stat -c %u $WHO)
 GROUPID=$(stat -c %g $WHO)
 
-deluser tim > /dev/null 2>&1
+deluser --remove-home tim > /dev/null 2>&1
+
+USERNAME=$(getent passwd "$USERID" | cut -d: -f1)
+if [ ! -z ${USERNAME} ]; then
+  deluser --remove-home $USERNAME > /dev/null 2>&1
+fi
+
+GROUPNAME=$(getent group "$GROUPID" | cut -d: -f1)
+if [ ! -z ${GROUPNAME} ]; then
+  delgroup $GROUPNAME > /dev/null 2>&1
+fi
+
 addgroup -g $GROUPID tim
 adduser -u $USERID -G tim -D -s /bin/sh tim
 

--- a/make-tim.sh
+++ b/make-tim.sh
@@ -21,7 +21,7 @@ if [ -z ${USERNAME} ]; then
   USERNAME=tim
 else
   if [ -z $(id -gn "$USERNAME" | grep "$GROUPNAME") ]; then
-    usermod -a -G $GROUPNAME $USERNAME
+    adduser $USERNAME $GROUPNAME
   fi
 fi
 

--- a/make-tim.sh
+++ b/make-tim.sh
@@ -9,17 +9,22 @@ GROUPID=$(stat -c %g $WHO)
 
 deluser --remove-home tim > /dev/null 2>&1
 
-USERNAME=$(getent passwd "$USERID" | cut -d: -f1)
-if [ ! -z ${USERNAME} ]; then
-  deluser --remove-home $USERNAME > /dev/null 2>&1
-fi
-
 GROUPNAME=$(getent group "$GROUPID" | cut -d: -f1)
-if [ ! -z ${GROUPNAME} ]; then
-  delgroup $GROUPNAME > /dev/null 2>&1
+if [ -z ${GROUPNAME} ]; then
+  addgroup -g $GROUPID tim
+  GROUPNAME=tim
 fi
 
-addgroup -g $GROUPID tim
-adduser -u $USERID -G tim -D -s /bin/sh tim
+USERNAME=$(getent passwd "$USERID" | cut -d: -f1)
+if [ -z ${USERNAME} ]; then
+  adduser -u $USERID -G $GROUPNAME -D -s /bin/sh tim
+  USERNAME=tim
+else
+  if [ -z $(id -gn "$USERNAME" | grep "$GROUPNAME") ]; then
+    usermod -a -G $GROUPNAME $USERNAME
+  fi
+fi
 
-gosu tim "$@"
+
+
+gosu $USERNAME "$@"


### PR DESCRIPTION
when used in some base image like node, there exists some user that has the same groupid or userid as the **tim** user do. so we can just use the existing user!